### PR TITLE
Fixed bug in typesetting.

### DIFF
--- a/src/www/js/CtData/CtDataCleaner/ApparatusEntryPositionCleaner.ts
+++ b/src/www/js/CtData/CtDataCleaner/ApparatusEntryPositionCleaner.ts
@@ -1,6 +1,7 @@
 import {CtDataCleaner} from './CtDataCleaner';
 import {CtDataInterface, WitnessTokenInterface} from "../CtDataInterface";
 
+
 export class ApparatusEntryPositionCleaner extends CtDataCleaner {
 
   /**
@@ -14,6 +15,7 @@ export class ApparatusEntryPositionCleaner extends CtDataCleaner {
       // not apparatuses to fix!
       return ctData;
     }
+    const EntryToBeDeleted = -1234; // assigning this value to the 'from' index signals that the entry should be deleted
     this.verbose && console.log(`Checking consistency in entry positions`);
     let errorsFound = false;
     let errorsNotFixed = false;
@@ -31,7 +33,8 @@ export class ApparatusEntryPositionCleaner extends CtDataCleaner {
 
         if (fromToken === undefined) {
           errorsFound = true;
-          console.warn(`Apparatus ${app.type}: entry ${entryIndex} with 'from' index ${entry.from} refers to undefined token`);
+          entry.from = EntryToBeDeleted;
+          console.warn(`Apparatus ${app.type}: entry ${entryIndex} with 'from' index ${entry.from} refers to undefined token, entry will be deleted`);
         } else {
           if (fromToken.tokenType !== 'word' && fromToken.tokenType !== 'punctuation') {
             errorsFound = true;
@@ -39,8 +42,9 @@ export class ApparatusEntryPositionCleaner extends CtDataCleaner {
             console.warn(`Apparatus ${app.type}: entry ${entryIndex} with 'from' index ${entry.from} refers to non-printable token (${fromToken.tokenType})`);
             let newIndex = this.findPrintableIndex(editionWitnessTokens, entry.from, entry.to, true);
             if (newIndex === -1) {
-              console.warn(`Could not fix the problem`);
+              console.warn(`Could not fix the problem, entry will be deleted`);
               errorsNotFixed = true;
+              entry.from = EntryToBeDeleted;
             } else {
               console.log(`Problem fixed, new 'from' index is ${newIndex}`);
               entry.from = newIndex;
@@ -49,7 +53,8 @@ export class ApparatusEntryPositionCleaner extends CtDataCleaner {
         }
         if (toToken === undefined) {
           errorsFound = true;
-          console.warn(`Apparatus ${app.type}: entry ${entryIndex} with 'to' index ${entry.to} refers to undefined token`);
+          entry.from = EntryToBeDeleted;
+          console.warn(`Apparatus ${app.type}: entry ${entryIndex} with 'to' index ${entry.to} refers to undefined token, entry will be deleted`);
         } else {
           if (toToken.tokenType !== 'word' && toToken.tokenType !== 'punctuation') {
             errorsFound = true;
@@ -66,7 +71,7 @@ export class ApparatusEntryPositionCleaner extends CtDataCleaner {
           }
         }
         return entry;
-      });
+      }).filter(entry => entry.from !== EntryToBeDeleted);
       return app;
     });
     if (errorsFound) {

--- a/src/www/js/CtData/CtDataInterface.ts
+++ b/src/www/js/CtData/CtDataInterface.ts
@@ -57,7 +57,7 @@ export interface CustomApparatusEntryInterface {
   lemma: CompactFmtText;
   postLemma: CompactFmtText;
   preLemma: CompactFmtText;
-  separator: string;
+  separator: CompactFmtText;
   subEntries: CustomApparatusSubEntryInterface[];
   tags: string[];
 }

--- a/src/www/js/Edition/ApparatusEntry.ts
+++ b/src/www/js/Edition/ApparatusEntry.ts
@@ -16,7 +16,7 @@ export class ApparatusEntry implements ApparatusEntryInterface {
   lemma: CompactFmtText;
   postLemma: CompactFmtText;
   lemmaText: string;
-  separator: string;
+  separator: CompactFmtText;
   tags: string[];
   subEntries: ApparatusSubEntry[];
   metadata: MetadataInterface;

--- a/src/www/js/Edition/EditionInterface.ts
+++ b/src/www/js/Edition/EditionInterface.ts
@@ -77,7 +77,7 @@ export interface ApparatusEntryInterface {
   lemma: CompactFmtText;
   postLemma: CompactFmtText;
   lemmaText: string;
-  separator: string;
+  separator: CompactFmtText;
   tags: string[];
   subEntries: ApparatusSubEntryInterface[];
   metadata: MetadataInterface;

--- a/src/www/js/Edition/EditionTypesetting.ts
+++ b/src/www/js/Edition/EditionTypesetting.ts
@@ -53,7 +53,7 @@ import {ApparatusInterface} from "./EditionInterface.js";
 import {Dimension} from "../lib/Typesetter2/Dimension.js";
 import {Edition} from './Edition.js';
 import {Apparatus} from "./Apparatus.js";
-import {fromString, fromCompactFmtText, getPlainText} from "../lib/FmtText/FmtText.js";
+import {fromCompactFmtText, fromString, getPlainText} from "../lib/FmtText/FmtText.js";
 
 export const MAX_LINE_COUNT = 10000;
 const enDash = '\u2013';
@@ -1207,7 +1207,10 @@ export class EditionTypesetting {
 
         default:
           // custom separator
-          items.push(...await this.getTsItemsForString(removeExtraWhiteSpace(entry.separator), 'apparatus', this.textDirection));
+          console.log(`Custom separator in entry`, entry.separator);
+          let separator = getPlainText(fromCompactFmtText(entry.separator));
+          separator = removeExtraWhiteSpace(separator);
+          items.push(...await this.getTsItemsForString(separator, 'apparatus', this.textDirection));
           break;
       }
       items.push((await this.createGlue('apparatus')).setTextDirection(this.textDirection));

--- a/src/www/js/EditionComposer/ApparatusPanel.ts
+++ b/src/www/js/EditionComposer/ApparatusPanel.ts
@@ -46,7 +46,7 @@ import {
 } from "@/CtData/CtDataInterface";
 import {WitnessDataItem} from "@/Edition/WitnessDataItem";
 import {Apparatus} from "@/Edition/Apparatus";
-import {fromCompactFmtText, getPlainText} from "@/lib/FmtText/FmtText";
+import {CompactFmtText, fromCompactFmtText, getPlainText} from "@/lib/FmtText/FmtText";
 
 const doubleVerticalLine = String.fromCodePoint(0x2016);
 const verticalLine = String.fromCodePoint(0x007c);
@@ -964,7 +964,7 @@ export class ApparatusPanel extends PanelWithToolbar {
         postLemmaSpan = ` <span class="pre-lemma">${postLemma}</span>`;
       }
 
-      let separator;
+      let separator: CompactFmtText;
 
       switch (apparatusEntry.separator) {
         case '':
@@ -986,6 +986,7 @@ export class ApparatusPanel extends PanelWithToolbar {
         default:
           separator = apparatusEntry.separator;
       }
+      separator = getPlainText(fromCompactFmtText(separator));
 
       html += `${lineHtml} ${preLemmaSpan}${lemmaSpan}${postLemmaSpan}${separator} `;
       apparatusEntry.subEntries.forEach((subEntry, subEntryIndex) => {
@@ -1421,10 +1422,11 @@ export class ApparatusPanel extends PanelWithToolbar {
 
   private loadLemmaGroupVariableInForm(variable: string, appEntry: ApparatusEntry, toggle: MultiToggle, textInput: JQuery<HTMLElement>) {
     const entry = appEntry as { [key: string]: any };
-    let option = this.getLemmaGroupVariableToggleOption(entry[variable]);
+    let option = this.getLemmaGroupVariableToggleOption(entry[variable], toggle);
     toggle.setOptionByName(option);
     if (option === 'custom') {
-      textInput.removeClass('hidden').val(entry[variable]);
+      const stringVal = getPlainText(fromCompactFmtText(entry[variable]));
+      textInput.removeClass('hidden').val(stringVal);
     } else {
       textInput.addClass('hidden').val('');
     }
@@ -1451,8 +1453,7 @@ export class ApparatusPanel extends PanelWithToolbar {
       }
       // @ts-expect-error using editedEntry as { [key: string]: any }
       this.editedEntry[variable] = this.getLemmaGroupVariableFromToggle(toggle, textInput);
-      // @ts-expect-error using editedEntry as { [key: string]: any }
-      if (Array.isArray(this.editedEntry[variable])) {
+      if (toggle.getOption() === 'custom') {
         textInput.removeClass('hidden');
       } else {
         textInput.addClass('hidden');
@@ -1461,14 +1462,15 @@ export class ApparatusPanel extends PanelWithToolbar {
     };
   }
 
-  private getLemmaGroupVariableToggleOption(variableValue: any) {
+  private getLemmaGroupVariableToggleOption(variableValue: CompactFmtText, toggle: MultiToggle) {
     if (variableValue === '') {
       return 'auto';
     }
-    if (Array.isArray(variableValue)) {
-      return 'custom';
+    const stringVal = getPlainText(fromCompactFmtText(variableValue));
+    if (toggle.getOptionNames().includes(stringVal)) {
+      return stringVal;
     }
-    return variableValue;
+    return 'custom';
   }
 
   private generateApparatusEntryFormHtml() {

--- a/src/www/js/widgets/MultiToggle.js
+++ b/src/www/js/widgets/MultiToggle.js
@@ -23,7 +23,7 @@
  *
  */
 
-import {OptionsChecker} from '@thomas-inst/optionschecker'
+import { OptionsChecker } from '@thomas-inst/optionschecker'
 
 export const optionChange = 'toggle'
 
@@ -38,16 +38,16 @@ export class MultiToggle {
   constructor (options) {
 
     let optionsDefinition = {
-      containerSelector : { type: 'string', required: true},
-      title: { type: 'string', required: false, default: ''},
-      onClass: { type: 'string', required: false, default: defaultOnClass},
-      buttonClass: {type: 'string', required: false, default: defaultButtonClass},
-      hoverClass: {type: 'string', required: false, default: defaultHoverClass},
-      buttonDef: { type: 'Array', required: true},
-      wrapButtonsInDiv: { type: 'boolean', required: false, default: false},
-      buttonsDivClass: {type: 'string', required: false, default: defaultButtonDiv},
-      initialOption: { type: 'string', required:false, default: ''},
-      onToggle : {
+      containerSelector: { type: 'string', required: true },
+      title: { type: 'string', required: false, default: '' },
+      onClass: { type: 'string', required: false, default: defaultOnClass },
+      buttonClass: { type: 'string', required: false, default: defaultButtonClass },
+      hoverClass: { type: 'string', required: false, default: defaultHoverClass },
+      buttonDef: { type: 'Array', required: true },
+      wrapButtonsInDiv: { type: 'boolean', required: false, default: false },
+      buttonsDivClass: { type: 'string', required: false, default: defaultButtonDiv },
+      initialOption: { type: 'string', required: false, default: '' },
+      onToggle: {
         type: 'function',
         required: false,
         default: null
@@ -55,12 +55,12 @@ export class MultiToggle {
     }
 
     let buttonDefDefinition = {
-       label: { type: 'string', required:true},
-       name: { type: 'string', required: true},
-       helpText: { type: 'string', required: false, default: ''}
+      label: { type: 'string', required: true },
+      name: { type: 'string', required: true },
+      helpText: { type: 'string', required: false, default: '' }
     }
 
-    let oc = new OptionsChecker({optionsDefinition: optionsDefinition, context:  "MultiToggle"})
+    let oc = new OptionsChecker({ optionsDefinition: optionsDefinition, context: 'MultiToggle' })
     this.options = oc.getCleanOptions(options)
 
     // check button definitions
@@ -68,49 +68,55 @@ export class MultiToggle {
       console.error('Less than two buttons defined in multi toggle')
     }
 
-    this.buttonDef = this.options.buttonDef.map( (def, i) => {
-      let checker = new OptionsChecker({optionsDefinition: buttonDefDefinition, context: `MultiToggle Button Def ${i}`})
+    this.buttonDef = this.options.buttonDef.map((def, i) => {
+      let checker = new OptionsChecker({
+        optionsDefinition: buttonDefDefinition,
+        context: `MultiToggle Button Def ${i}`
+      })
       return checker.getCleanOptions(def)
     })
 
     if (this.options.initialOption === '') {
       this.currentOptionIndex = 0
     } else {
-      this.currentOptionIndex = this.buttonDef.findIndex( def => { return def.name === this.options.initialOption})
+      this.currentOptionIndex = this.buttonDef.findIndex(def => { return def.name === this.options.initialOption})
     }
 
     this.container = $(this.options.containerSelector)
     this.container.html(this.getWidgetHtml())
     // save button elements
-    this.buttonDef = this.buttonDef.map( (def, i) => {
+    this.buttonDef = this.buttonDef.map((def, i) => {
       def.element = $(this.getButtonSelectorWithIndex(i))
       return def
     })
     //console.log(this.buttonDef)
 
-    this.buttonDef.forEach( (def, i) => {
+    this.buttonDef.forEach((def, i) => {
       def.element.on('click', this.genOnClickButton(i))
     })
   }
 
+  getOptionNames () {
+    return this.buttonDef.map((def) => { return def.name})
+  }
 
-  getWidgetHtml() {
+  getWidgetHtml () {
 
     let html = ''
-    html += this.options.title !== '' ?  this._wrapInDiv(`<span class="${titleClass}">${this.options.title}</span>`) : ''
-    html += this.buttonDef.map( (def, i) => {
+    html += this.options.title !== '' ? this._wrapInDiv(`<span class="${titleClass}">${this.options.title}</span>`) : ''
+    html += this.buttonDef.map((def, i) => {
       let buttonClasses = []
       buttonClasses.push(this.options.buttonClass)
       buttonClasses.push(this.options.buttonClass + '-' + i)
-      if (i===this.currentOptionIndex) {
+      if (i === this.currentOptionIndex) {
         buttonClasses.push(this.options.onClass)
       }
-      return this._wrapInDiv(`<a href='#' class="${ buttonClasses.join(' ')}" title="${def.helpText}">${def.label}</a>`)
+      return this._wrapInDiv(`<a href='#' class="${buttonClasses.join(' ')}" title="${def.helpText}">${def.label}</a>`)
     }).join('')
     return html
   }
 
-  _wrapInDiv(html) {
+  _wrapInDiv (html) {
     if (this.options.wrapButtonsInDiv) {
       return `<div class="${this.options.buttonsDivClass}">${html}</div>`
     } else {
@@ -118,7 +124,7 @@ export class MultiToggle {
     }
   }
 
-  genOnClickButton(index) {
+  genOnClickButton (index) {
     return () => {
       if (this.currentOptionIndex === index) {
         // nothing to do
@@ -136,7 +142,7 @@ export class MultiToggle {
     }
   }
 
-  setOptionByIndex(newOptionIndex, dispatchOptionChangeEvent = false) {
+  setOptionByIndex (newOptionIndex, dispatchOptionChangeEvent = false) {
     let lastOption = this.currentOptionIndex
     this.buttonDef[this.currentOptionIndex].element.removeClass(this.options.onClass)
     this.currentOptionIndex = newOptionIndex
@@ -144,12 +150,13 @@ export class MultiToggle {
     if (dispatchOptionChangeEvent) {
       this.dispatchEvent(optionChange, {
         currentOption: this.getOption(),
-        previousOption: this.buttonDef[lastOption].name })
+        previousOption: this.buttonDef[lastOption].name
+      })
     }
   }
 
-  setOptionByName(newOption, dispatchOptionChangeEvent = false) {
-    let newOptionIndex = this.buttonDef.map( (button) => { return button.name}).indexOf(newOption)
+  setOptionByName (newOption, dispatchOptionChangeEvent = false) {
+    let newOptionIndex = this.buttonDef.map((button) => { return button.name}).indexOf(newOption)
     if (newOptionIndex === -1) {
       console.warn(`Attempt to set an non-existent option ${newOption}`)
       return
@@ -157,22 +164,20 @@ export class MultiToggle {
     this.setOptionByIndex(newOptionIndex, dispatchOptionChangeEvent)
   }
 
-
-  getOption() {
+  getOption () {
     return this.buttonDef[this.currentOptionIndex].name
   }
 
-  getButtonSelector() {
+  getButtonSelector () {
     return `${this.options.containerSelector} .${this.options.buttonClass}`
   }
 
-  getButtonSelectorWithIndex(i) {
+  getButtonSelectorWithIndex (i) {
     return `${this.options.containerSelector} .${this.options.buttonClass}-${i}`
   }
 
-
-  dispatchEvent(eventName, data = {}){
-    const event = new CustomEvent(eventName, {detail: data})
+  dispatchEvent (eventName, data = {}) {
+    const event = new CustomEvent(eventName, { detail: data })
     this.container.get()[0].dispatchEvent(event)
   }
 
@@ -182,7 +187,7 @@ export class MultiToggle {
    * @param {String} eventName
    * @param {function} f
    */
-  on(eventName, f)  {
+  on (eventName, f) {
     this.container.on(eventName, f)
   }
 


### PR DESCRIPTION
 Fixed also an unnoticed problem in the EditonComposer: the custom lemma, separator, etc were not allowing entering custom text.

Made a change in the consistency check of CtData: now entries that point to unprintable or undefined main text tokens are filtered out; they used to be shown before the text, which is not only wrong but also very confusing.