### PR TITLE
Fixed column deletion logic

### DIFF
--- a/src/www/js/EditionComposer/CollationTablePanel.ts
+++ b/src/www/js/EditionComposer/CollationTablePanel.ts
@@ -793,19 +793,18 @@ export class CollationTablePanel extends PanelWithToolbar {
 
   genOnColumnDelete() {
     return (deletedCol: number, isLastDeleted: boolean) => {
-      this.ctData['groupedColumns'] = this.tableEditor.columnSequence.getGroupedNumbers();
-      if (this.ctData['type'] === CollationTableType.COLLATION_TABLE) {
+      this.ctData.groupedColumns = this.tableEditor.columnSequence.getGroupedNumbers();
+      if (this.ctData.type === CollationTableType.COLLATION_TABLE) {
         // nothing else to do for regular collation tables
         return;
       }
       this.syncEditionWitnessAndTableEditorFirstRow();
-      this.ctData['collationMatrix'] = this.getCollationMatrixFromTableEditor();
+      this.ctData.collationMatrix= this.getCollationMatrixFromTableEditor();
       // fix references in custom apparatuses
-      this.ctData['customApparatuses'] = CtData.fixReferencesInCustomApparatusesAfterColumnAdd(this.ctData, deletedCol, -1);
+      this.ctData.customApparatuses = CtData.fixReferencesInCustomApparatusesAfterColumnAdd(this.ctData, deletedCol, -1);
       this.setCsvDownloadFile();
       if (isLastDeleted) {
         this.delayedOnCtDataChange(this.ctData);
-        // this.options.onCtDataChange(this.ctData);
       }
     };
   }
@@ -883,15 +882,9 @@ export class CollationTablePanel extends PanelWithToolbar {
           let editionWitnessIndex = this.ctData['witnessOrder'][0];
           let editionToken = this.ctData.witnesses[editionWitnessIndex]['tokens'][theMatrixCol[0]];
           if (editionToken !== undefined && editionToken.tokenType !== TranscriptionTokenType.EMPTY) {
-            // an undefined editionToken means that the edition token is empty
             return false;
           }
-          for (let i = 1; i < theMatrixCol.length; i++) {
-            if (theMatrixCol[i] !== -1) {
-              return false;
-            }
-          }
-          return true;
+          return this.tableEditor.isColumnEmpty(col);
 
         default:
           console.warn('Unknown collation table type!');

--- a/src/www/js/pages/common/TableEditor/TableEditor.ts
+++ b/src/www/js/pages/common/TableEditor/TableEditor.ts
@@ -167,7 +167,9 @@ interface TableEditorOptions<T> {
   generateCellClasses?: (row: number, col: number, value: T) => string[];
   generateCellTdExtraAttributes?: (row: number, col: number, value: T) => TdExtraAttributes[];
   cellValidationFunction: (row: number, col: number, currentText: string) => CellValidationReport;
-  canDeleteColumn?: (col: number) => boolean;
+  //
+  // A function to test if a column can be deleted. If it returns null, the default behavior is used.
+  canDeleteColumn?: (col: number) => boolean|null;
   emptyCellHtml?: string;
   debug?: boolean;
 }
@@ -284,7 +286,7 @@ export class TableEditor<T> {
       onCellDrawnEventHandler: null,
       onTableDrawnEventHandler: () => {
       },
-      canDeleteColumn: () => true,
+      canDeleteColumn: () => null,
       onContentChangedEventHandler: () => {
       },
       onColumnGroupEventHandler: () => {
@@ -522,9 +524,9 @@ export class TableEditor<T> {
     return classes;
   }
 
-  redrawCell(_row: number, _col: number) {
-    this.redrawTable();
-  }
+  // redrawCell(_row: number, _col: number) {
+  //   this.redrawTable();
+  // }
 
   // getRow(row: number) {
   //   return this.matrix.getRow(row);
@@ -534,9 +536,9 @@ export class TableEditor<T> {
   //   return this.matrix.getColumn(col);
   // }
 
-  refreshCell(_row: number, _col: number) {
-    this.redrawTable();
-  }
+  // refreshCell(_row: number, _col: number) {
+  //   this.redrawTable();
+  // }
 
 
   // getRowTitle(row: number) {
@@ -564,13 +566,13 @@ export class TableEditor<T> {
     return this.columnSequence.isGroupedWithPrevious(col);
   }
 
-  refreshCellContent(_row: number, _col: number) {
-    this.redrawTable();
-  }
-
-  refreshCellClassesTd(_td: HTMLElement, _row: number, _col: number) {
-    this.redrawTable();
-  }
+  // refreshCellContent(_row: number, _col: number) {
+  //   this.redrawTable();
+  // }
+  //
+  // refreshCellClassesTd(_td: HTMLElement, _row: number, _col: number) {
+  //   this.redrawTable();
+  // }
 
   refreshCellClasses(_row: number, _col: number) {
     this.redrawTable();
@@ -599,18 +601,18 @@ export class TableEditor<T> {
   //     this.redrawTable();
   //   }
   // }
-
-  public refreshColumn(_col: number) {
-    this.redrawTable();
-  }
-
-  public refreshColumnClasses(_col: number) {
-    this.redrawTable();
-  }
-
-  refreshCellAttributes(_row: number, _col: number) {
-    this.redrawTable();
-  }
+  //
+  // public refreshColumn(_col: number) {
+  //   this.redrawTable();
+  // }
+  //
+  // public refreshColumnClasses(_col: number) {
+  //   this.redrawTable();
+  // }
+  //
+  // refreshCellAttributes(_row: number, _col: number) {
+  //   this.redrawTable();
+  // }
 
   enterCellEditMode(row: number, col: number) {
     //console.log('Entering edit mode, ' + row + ':' + col)
@@ -767,14 +769,14 @@ export class TableEditor<T> {
     return 'te-table-' + tableNumber;
   }
 
-  getTableNumberForColumn(col: number) {
-    if (this.options.showInMultipleRows) {
-      return Math.floor(col / this.options.columnsPerRow);
-    } else {
-      return 0;
-    }
-
-  }
+  // getTableNumberForColumn(col: number) {
+  //   if (this.options.showInMultipleRows) {
+  //     return Math.floor(col / this.options.columnsPerRow);
+  //   } else {
+  //     return 0;
+  //   }
+  //
+  // }
 
   getTdClass(row: number, col: number) {
     return specificCellClassPrefix + row + '-' + col;
@@ -801,11 +803,24 @@ export class TableEditor<T> {
   }
 
   isColumnEmpty(col: number) {
-    return this.matrix.isColumnEmpty(col, this.options.isEmptyValue);
+    if (this.matrix.isColumnEmpty(col, this.options.isEmptyValue)) {
+      return true;
+    }
+    // now check if the column is empty by checking if all cells are empty
+    for (let row = 0; row < this.matrix.nRows; row++) {
+      if (!this.options.isEmptyValue(row, col, this.matrix.getValue(row, col))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   canDeleteColumn(col: number) {
-    return this.options.canDeleteColumn ? this.options.canDeleteColumn(col) : this.isColumnEmpty(col);
+    const optionalCheckerResult = this.options.canDeleteColumn(col);
+    if (optionalCheckerResult !== null) {
+      return optionalCheckerResult;
+    }
+    return this.isColumnEmpty(col);
   }
 
   canMoveCellLeft(row: number, col: number) {
@@ -1222,7 +1237,7 @@ export class TableEditor<T> {
             this.waitingForScrollZero = true;
             this.deleteSingleColumnData(col);
             if (this.options.onColumnDelete) {
-              this.options.onColumnDelete(col, false);
+              this.options.onColumnDelete(col, true);
             }
             this.redrawTable();
             this.forceRestoreScroll(250);


### PR DESCRIPTION
Now it also checks to see if the token references point to empty tokens.

Also, fixed an unnoticed bug in which deleting a column by clicking on the delete button did not enable the save button for the chunk edition